### PR TITLE
refactor(links): add tail slash to category and tag link

### DIFF
--- a/themes/simplecss/layouts/_default/single.html
+++ b/themes/simplecss/layouts/_default/single.html
@@ -10,14 +10,14 @@
           {{ if .Params.categories }}
           <div>
             {{ range .Params.categories }}
-              <a href="{{ "/categories/" | relLangURL }}{{ . | urlize }}"><mark>{{ . }}</mark></a>
+              <a href="{{ "/categories/" | relLangURL }}{{ . | urlize }}/"><mark>{{ . }}</mark></a>
             {{ end }}
           </div>
           {{ end }}
           {{ if .Params.tags }}
           <div>
             {{ range .Params.tags }}
-              <a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}"><mark>{{ . }}</mark></a>
+              <a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}/"><mark>{{ . }}</mark></a>
             {{ end }}
           </div>
           {{ end }}


### PR DESCRIPTION
Ref: https://github.com/alanorth/hugo-theme-bootstrap4-blog/issues/128